### PR TITLE
Fix error with woody.error-reason header

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     </parent>
 
     <artifactId>adapter-common-lib</artifactId>
-    <version>1.2.8</version>
+    <version>1.2.9</version>
     <packaging>jar</packaging>
 
     <name>adapter-common-lib</name>

--- a/src/main/java/dev/vality/adapter/common/mapper/ErrorMapping.java
+++ b/src/main/java/dev/vality/adapter/common/mapper/ErrorMapping.java
@@ -133,11 +133,12 @@ public class ErrorMapping {
     }
 
     private WRuntimeException getUnexpectedError(String code, String description, String state) {
+        String errorMessage = String.format("Unexpected result, code = %s, description = %s, state = %s",
+                code, description, state);
+
         var errorDefinition = new WErrorDefinition(WErrorSource.INTERNAL);
         errorDefinition.setErrorType(WErrorType.UNEXPECTED_ERROR);
-        return new WRuntimeException(
-                String.format("Unexpected result, code = %s, description = %s, state = %s",
-                        code, description, state),
-                errorDefinition);
+        errorDefinition.setErrorReason(errorMessage);
+        return new WRuntimeException(errorMessage, errorDefinition);
     }
 }


### PR DESCRIPTION
Исправление ошибки ```got response with http code 500 and without woody.error-reason header"```, когда hellgate не понимает по какой причине прилетела Unexpected ошибка при невозможности маппинга на адаптере. Этот фикс поможет видеть ошибки мапинга сразу в repairer сервисе без необходимости смотреть в логи.